### PR TITLE
refresh_token:

### DIFF
--- a/src/main/java/com/example/pentaho/cofig/WebMvcConfig.java
+++ b/src/main/java/com/example/pentaho/cofig/WebMvcConfig.java
@@ -37,7 +37,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         "/api/singlequery/**",
                         "/api/single-track-query/**",
                         "/api/bigdata/**",
-                        "/api/api-key/getAuthorization",
+                        "/api/api-key/get-api-key",
+                        "/api/api-key/create-api-key",
                         "/api/api-key/forapikey",
                         "/api/api-key/forguest"
                         );

--- a/src/main/java/com/example/pentaho/component/RefreshToken.java
+++ b/src/main/java/com/example/pentaho/component/RefreshToken.java
@@ -6,7 +6,9 @@ public class RefreshToken {
 
     private String id;
     private String refreshToken;
+    private String token;
     private Instant expiryDate;
+    private Instant refreshTokenExpiryDate;
     private User user;
 
 
@@ -44,4 +46,20 @@ public class RefreshToken {
         this.user = user;
     }
 
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public Instant getRefreshTokenExpiryDate() {
+        return refreshTokenExpiryDate;
+    }
+
+    public void setRefreshTokenExpiryDate(Instant refreshTokenExpiryDate) {
+        this.refreshTokenExpiryDate = refreshTokenExpiryDate;
+    }
 }

--- a/src/main/java/com/example/pentaho/component/Token.java
+++ b/src/main/java/com/example/pentaho/component/Token.java
@@ -121,7 +121,7 @@ public class Token {
 
 
 
-    public static boolean findExpireDateOfRefreshToken(String RSAJWTToken,String keyName) throws ExpiredJwtException, NoSuchAlgorithmException, FileNotFoundException, InvalidKeySpecException {
+    public static boolean findExpireDateOfToken(String RSAJWTToken,String keyName) throws ExpiredJwtException, NoSuchAlgorithmException, FileNotFoundException, InvalidKeySpecException {
             log.info("keyName:{}", keyName);
             File file = ResourceUtils.getFile(keyName);
             byte[] keyBytes = readFileAsBytes(file);
@@ -158,7 +158,7 @@ public class Token {
             Jws<Claims> claimsJws = Jwts.parser().setSigningKey(publicKey).parseClaimsJws(RSAJWTToken);
             Claims body = claimsJws.getBody();
             log.info("body:{}", body.toString());
-            log.info("userInfo",body.get("userInfo"));
+            log.info("userInfo:{}",body.get("userInfo"));
             String userInfo = gson.toJson(body.get("userInfo"));
             return objectMapper.readValue(userInfo,User.class);
         } catch (Exception e) {

--- a/src/main/java/com/example/pentaho/component/User.java
+++ b/src/main/java/com/example/pentaho/component/User.java
@@ -38,8 +38,8 @@ public class User  {
     @JsonProperty("roles")
     private List<String> roles;
 
-
-
+    @JsonProperty("tokenType")
+    private String tokenType;
 
     /**使用者ID*/
     @JsonProperty("id")
@@ -81,6 +81,7 @@ public class User  {
             this.username = user.username;
             this.orgId = user.orgId;
             this.departName = user.departName;
+            this.tokenType = user.tokenType;
         } catch (JsonProcessingException e) {
         }
     }
@@ -191,6 +192,13 @@ public class User  {
         this.roles = roles;
     }
 
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
 
     @Override
     public String toString() {
@@ -203,6 +211,7 @@ public class User  {
                 ", localizeName='" + localizeName + '\'' +
                 ", email='" + email + '\'' +
                 ", roles=" + roles +
+                ", tokenType='" + tokenType + '\'' +
                 ", id='" + id + '\'' +
                 ", username='" + username + '\'' +
                 ", orgId='" + orgId + '\'' +

--- a/src/main/java/com/example/pentaho/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/pentaho/repository/RefreshTokenRepository.java
@@ -1,8 +1,10 @@
 package com.example.pentaho.repository;
 
+import com.example.pentaho.component.JwtReponse;
 import com.example.pentaho.component.RefreshToken;
 import org.springframework.stereotype.Repository;
 
+import java.text.ParseException;
 import java.util.List;
 
 @Repository
@@ -14,6 +16,11 @@ public interface RefreshTokenRepository {
 
     List<RefreshToken> findByRefreshTokenAndUserId(String refreshToken, String id);
 
-    void deleteByRefreshToken(RefreshToken refreshToken);
+    void deleteByRefreshToken(String refreshToken);
+
+    void deleteByToken(String token);
+
+    void updateTokenByUserId(String id, JwtReponse reponse) throws ParseException;
+
 
 }

--- a/src/main/java/com/example/pentaho/repository/impl/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/example/pentaho/repository/impl/RefreshTokenRepositoryImpl.java
@@ -2,12 +2,17 @@ package com.example.pentaho.repository.impl;
 
 import com.cht.commons.persistence.query.Query;
 import com.cht.commons.persistence.query.SqlExecutor;
+import com.example.pentaho.component.JwtReponse;
 import com.example.pentaho.component.RefreshToken;
 import com.example.pentaho.repository.RefreshTokenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
 import java.util.List;
 
 @Repository
@@ -23,8 +28,11 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
     @Override
     public void saveRefreshToken(RefreshToken refreshToken) {
         Query query = Query.builder()
-                .append("insert into ADDR_ODS.REFRESH_TOKEN (id, refresh_token, expiry_date)")
-                .append("VALUES (:id, :refreshtoken, CAST(:expirydate AS DATETIME))", refreshToken.getId(), refreshToken.getRefreshToken(), java.sql.Timestamp.from(refreshToken.getExpiryDate()))
+                .append("insert into ADDR_ODS.REFRESH_TOKEN (id, refresh_token, refresh_token_expiry_date, token ,expiry_date )")
+                .append("VALUES (:id, :refreshtoken, CAST(:refreshtokenexpirydate AS DATETIME), :token, CAST(:expirydate AS DATETIME))",
+                        refreshToken.getId(),
+                        refreshToken.getRefreshToken(), java.sql.Timestamp.from(refreshToken.getRefreshTokenExpiryDate()),
+                        refreshToken.getToken(), java.sql.Timestamp.from(refreshToken.getExpiryDate()))
                 .build();
         log.info("query:{}", query);
         log.info("params:{}", query.getParameters());
@@ -54,14 +62,38 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
     }
 
     @Override
-    public void deleteByRefreshToken(RefreshToken refreshToken) {
+    public void deleteByRefreshToken(String refreshToken) {
         Query query = Query.builder()
                 .append("delete FROM ADDR_ODS.REFRESH_TOKEN")
-                .append("WHERE refresh_token = :refreshToken", refreshToken.getRefreshToken())
+                .append("WHERE refresh_token = :refreshToken", refreshToken)
                 .build();
         log.info("query:{}", query);
         log.info("params:{}", query.getParameters());
         sqlExecutor.delete(query);
+    }
+
+    @Override
+    public void deleteByToken(String token) {
+        Query query = Query.builder()
+                .append("delete FROM ADDR_ODS.REFRESH_TOKEN")
+                .append("WHERE token = :token", token)
+                .build();
+        log.info("query:{}", query);
+        log.info("params:{}", query.getParameters());
+        sqlExecutor.delete(query);
+    }
+
+    @Override
+    public void updateTokenByUserId(String userId, JwtReponse reponse) throws ParseException {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date expiryDate = dateFormat.parse(String.valueOf(reponse.getExpiryDate()));
+        Query query = Query.builder()
+                .append("update ADDR_ODS.REFRESH_TOKEN set token = :token , expiry_Date = :expiryDate", reponse.getToken(), java.sql.Timestamp.from(expiryDate.toInstant()))
+                .append("WHERE id = :id", userId)
+                .build();
+        log.info("query:{}", query);
+        log.info("params:{}", query.getParameters());
+        sqlExecutor.update(query);
     }
 
 }

--- a/src/main/java/com/example/pentaho/service/ApiKeyService.java
+++ b/src/main/java/com/example/pentaho/service/ApiKeyService.java
@@ -1,6 +1,7 @@
 package com.example.pentaho.service;
 
 import com.example.pentaho.component.*;
+import com.example.pentaho.exception.MoiException;
 import com.example.pentaho.utils.RSAJWTUtils;
 import com.example.pentaho.utils.RsaUtils;
 import com.example.pentaho.utils.UserContextUtils;
@@ -10,6 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.PrivateKey;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -23,20 +27,61 @@ public class ApiKeyService {
 
     private final int VALID_TIME = 1440;
 
-    public JwtReponse getApiKey(String userId, RefreshToken refreshToken) throws Exception {
-        User user = UserContextUtils.getUserHolder();
-        log.info("user:{}", user);
+    //返回該userID的api key
+    //同時檢查token有沒有過期，有過期的話，看refresh_token有沒有過期，refresh_token沒有過期重新卷token即可
+    //refresh_token有過期，整組要重建，並返回給前端
+    public JwtReponse getApiKey(String userId) throws Exception {
+        List<RefreshToken> refreshTokens =  refreshTokenService.findByUserId(userId);
+        RefreshToken refreshToken;
+        JwtReponse jwtReponse = new JwtReponse();
+        if(!refreshTokens.isEmpty()){
+            refreshToken = refreshTokens.get(0);
+            //token沒有過期
+            if(refreshTokenService.verifyExpiration(refreshToken.getToken(),"token")){
+                //直接返回即可
+                jwtReponse.setRefreshToken(refreshToken.getRefreshToken());
+                jwtReponse.setRefreshTokenExpiryDate(String.valueOf(refreshToken.getRefreshTokenExpiryDate()));
+                jwtReponse.setToken(refreshToken.getToken());
+                jwtReponse.setExpiryDate(String.valueOf(refreshToken.getExpiryDate()));
+                return jwtReponse;
+            }else{
+                //token過期
+                //檢查refresh_token有無過期
+                if(refreshTokenService.verifyExpiration(refreshToken.getRefreshToken(),"refresh_token")){
+                    //refreshToken沒有過期，卷token即可
+                    return createApiKey(userId, refreshToken);
+                }else {
+                    //refreshToken也過期，全部重卷
+                    return createApiKey(userId, null);
+                }
+            }
+        }
+        return jwtReponse;
+    }
+
+
+    public JwtReponse createApiKey(String userId, RefreshToken refreshToken) throws Exception {
+        User user = new User();
         PrivateKey privateKey = RsaUtils.getPrivateKey((keyComponent.getApPrikeyName()));
         //一般token
+        user.setId(userId); //userId要用api帶過來的(如果是審核通過的)
+        user.setTokenType("token");
         Map<String, Object> toeknMap = RSAJWTUtils.generateTokenExpireInMinutes(user, privateKey, VALID_TIME); //一般TOKEN效期先設一天
         Token token = new Token((String) toeknMap.get("token"), (String) toeknMap.get("expiryDate"));
         //refresh_token
         Map<String, Object> refreshTokenMap = null;
+        //refreshToken == null，表示全新的申請
         if (refreshToken == null) {
-            refreshTokenMap = RSAJWTUtils.generateTokenExpireInMinutes(user, privateKey, VALID_TIME * 2);  //REFRESH_TOKEN效期先設2天
-            String newRefreshToken = (String) refreshTokenMap.get("token");
-            //refresh_token存table
-            refreshTokenService.saveRefreshToken(user == null ? userId : user.getId(), newRefreshToken);
+            List<RefreshToken>  refreshTokens = refreshTokenService.findByUserId(userId);
+            //找不到該userId相對應的TOKEN資料，才需要再存一筆新的，不然會重複申請
+            if(refreshTokens.isEmpty()){
+                user.setTokenType("refresh_token");
+                refreshTokenMap = RSAJWTUtils.generateTokenExpireInMinutes(user, privateKey, VALID_TIME*2);  //REFRESH_TOKEN效期先設2天
+                //token存table
+                refreshTokenService.saveRefreshToken(userId, toeknMap, refreshTokenMap);
+            }else{
+                throw new MoiException("該用戶已申請過ApiKey");
+            }
         }
         //設定返回給前端的物件
         JwtReponse jwtReponse = new JwtReponse();
@@ -46,4 +91,23 @@ public class ApiKeyService {
         jwtReponse.setExpiryDate(token.getExpiryDate());
         return jwtReponse;
     }
+
+
+    //終端user持有效的refreshToken，來換取token
+    public JwtReponse exchangeForNewToken(String userId) throws Exception {
+        User user = new User();
+        PrivateKey privateKey = RsaUtils.getPrivateKey((keyComponent.getApPrikeyName()));
+        //一般token
+        user.setId(userId); //userId要用api帶過來的(如果是審核通過的)
+        user.setTokenType("token");
+        Map<String, Object> tokenMap = RSAJWTUtils.generateTokenExpireInMinutes(user, privateKey, VALID_TIME); //一般TOKEN效期先設一天
+        JwtReponse response = new JwtReponse();
+        response.setExpiryDate((String) tokenMap.get("expiryDate")); //refresh_token，效期先設2天
+        response.setToken((String) tokenMap.get("token"));
+        //更新db裡的token、expiryDate
+        refreshTokenService.updateTokenByUserId(userId, response);
+        return response;
+    }
+
+
 }

--- a/src/main/java/com/example/pentaho/service/RefreshTokenService.java
+++ b/src/main/java/com/example/pentaho/service/RefreshTokenService.java
@@ -1,10 +1,6 @@
 package com.example.pentaho.service;
 
-import com.example.pentaho.component.KeyComponent;
-import com.example.pentaho.component.RefreshToken;
-import com.example.pentaho.component.Token;
-import com.example.pentaho.component.User;
-import com.example.pentaho.exception.MoiException;
+import com.example.pentaho.component.*;
 import com.example.pentaho.repository.RefreshTokenRepository;
 import com.example.pentaho.utils.UserContextUtils;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -16,10 +12,12 @@ import org.springframework.stereotype.Service;
 import java.io.FileNotFoundException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
-import java.time.Duration;
-import java.time.Instant;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
 import java.util.List;
-import java.util.UUID;
+import java.util.Map;
 
 @Service
 public class RefreshTokenService {
@@ -31,13 +29,18 @@ public class RefreshTokenService {
     @Autowired
     private KeyComponent keyComponent;
 
-    public RefreshToken saveRefreshToken(String id, String token) {
+    public RefreshToken saveRefreshToken(String id, Map<String, Object> tokenMap, Map<String, Object> refreshTokenMap) throws ParseException {
         User user = UserContextUtils.getUserHolder();
         log.info("user:{}", user);
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setId(id);
-        refreshToken.setRefreshToken(token);
-        refreshToken.setExpiryDate(Instant.now().plus(Duration.ofDays(2))); //refresh_token，效期先設一天
+        refreshToken.setRefreshToken((String) refreshTokenMap.get("token"));
+        refreshToken.setToken((String) tokenMap.get("token"));
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date expiryDate = dateFormat.parse(String.valueOf(tokenMap.get("expiryDate")));
+        Date refreshTokenExpiryDate = dateFormat.parse(String.valueOf(refreshTokenMap.get("expiryDate")));
+        refreshToken.setRefreshTokenExpiryDate(refreshTokenExpiryDate.toInstant()); //refresh_token，效期先設2天
+        refreshToken.setExpiryDate(expiryDate.toInstant()); //refresh_token，效期先設1天
         refreshTokenRepository.saveRefreshToken(refreshToken);
         return refreshToken;
     }
@@ -46,26 +49,43 @@ public class RefreshTokenService {
     /**
      * 檢查db是否有存這筆token
      */
-    public List<RefreshToken> findByRefreshToken(RefreshToken refreshToken) {
+    public List<RefreshToken> findByRefreshTokenAndUserId(RefreshToken refreshToken) {
         return refreshTokenRepository.findByRefreshTokenAndUserId(refreshToken.getRefreshToken(), refreshToken.getId());
     }
 
+
     /**
-     * 驗證refreshtoken是否有過期，過期的話db要刪掉該筆過期的refreshtoken
+     * 用userId找到該筆API_KEY資訊
      */
-    public Boolean verifyExpiration(RefreshToken refreshToken) {
+    public List<RefreshToken> findByUserId(String userId) {
+        return refreshTokenRepository.findById(userId);
+    }
+
+    /**
+     * 驗證token是否有過期，過期的話db要刪掉該筆過期的token
+     */
+    public Boolean verifyExpiration(String token, String type) {
         String keyName = keyComponent.getApPubkeyName();
         try {
-            if (Token.findExpireDateOfRefreshToken(refreshToken.getRefreshToken(), keyName)) {
+            if (Token.findExpireDateOfToken(token, keyName)) {
                 return true;
             }
         } catch (ExpiredJwtException e) {
             log.info(e.toString());
-            refreshTokenRepository.deleteByRefreshToken(refreshToken);
-            throw new MoiException(refreshToken.getRefreshToken() + "， refreshToken過期");
+            if("token".equals(type)){
+                refreshTokenRepository.deleteByToken(token);
+            }else{
+                refreshTokenRepository.deleteByRefreshToken(token);
+            }
+            log.info(token + "，" + type + "， token過期");
+            throw e;
         } catch (FileNotFoundException | NoSuchAlgorithmException | InvalidKeySpecException e) {
             log.info(e.toString());
         }
         return false;
+    }
+
+    public void updateTokenByUserId(String userId, JwtReponse reponse) throws ParseException {
+        refreshTokenRepository.updateTokenByUserId(userId, reponse);
     }
 }

--- a/src/main/java/com/example/pentaho/utils/AuthorizationHandlerInterceptor.java
+++ b/src/main/java/com/example/pentaho/utils/AuthorizationHandlerInterceptor.java
@@ -94,6 +94,11 @@ public class AuthorizationHandlerInterceptor implements HandlerInterceptor {
             if(Token.fromRSAJWTToken(RSATokenJwt,keyName)){
                 User user = Token.extractUserFromRSAJWTToken(RSATokenJwt,keyName);
                 log.info("user:{}",user);
+                //判斷使用者是不是拿refresh_token
+                if("refresh_token".equals(user.getTokenType())){
+                    log.info("使用者拿refresh_token打api,駁回");
+                    throw new ResponseStatusException(HttpStatus.FORBIDDEN, "not allowed");
+                }
                 UserContextUtils.setUserHolder(user);
                 return true;
             }


### PR DESCRIPTION
/create-api-key : 用途: 後臺核可之後，我們卷token、refreshToken，並存db。
                           帶參數: userId放在request param
                           帶token: 聖森token

/get-api-key  :   用途: 一版使用者要看他申請過的token、refreshToken
                           帶參數: userId放在request param
                           帶token: 聖森token
/refresh-token:   用途: 一般使用者，發現token過期了，要用refreshToken重新卷token
                            帶參數: userId放在body、refreshToken放body
                            帶token: 聖森token